### PR TITLE
First pass at adding an atom feed

### DIFF
--- a/bin/render.py
+++ b/bin/render.py
@@ -52,3 +52,19 @@ class Renderer:
             pageContent=page_content,
             **kwargs
         )
+
+    def render_content_feed(self, output_path, template, page_content, parent_dir, **kwargs):
+        template_name = "atom.xml"
+        try:
+            template = self.get_template(template_name)
+        except Exception as e:
+            print(e)
+
+        self.render(
+            output_path,
+            template,
+            breadcrumbs=create_breadcrumbs(output_path),
+            pageContent=page_content,
+            parentDir=parent_dir,
+            **kwargs
+        )        

--- a/render.py
+++ b/render.py
@@ -23,7 +23,7 @@ jinja_renderer = Renderer(url_root)
 
 content_template = jinja_renderer.get_template("content.html")
 list_template = jinja_renderer.get_template("list.html")
-
+feed_template = jinja_renderer.get_template("atom.xml.html")
 
 def get_content_pages(directory):
     return os.listdir(directory)
@@ -52,9 +52,12 @@ def render_pages(parent_dir=""):
                 render_pages(os.path.join(parent_dir, page))
             elif page.endswith(".md"):
                 if page == "_list.md":
+                    # create an index page and feed for each _list
                     list = create_list(pages, path_to_directory)
-                    output_path = os.path.join(output_dir, parent_dir, "index.html")
-                    jinja_renderer.render_content_page(output_path, list_template, list)
+                    content_output_path = os.path.join(output_dir, parent_dir, "index.html")
+                    feed_output_path = os.path.join(output_dir, parent_dir, "atom.xml")
+                    jinja_renderer.render_content_page(content_output_path, list_template, list)
+                    jinja_renderer.render_content_feed(feed_output_path, feed_template, list, parent_dir)
                 else:
                     # compile and render markdown file
                     fn = Path(p)

--- a/templates/atom.xml.html
+++ b/templates/atom.xml.html
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-GB">
+    <link rel="self" type="application/atom+xml" href="{{ staticPath + '/' + parentDir + '/atom.xml' }}"/>
     <title>{{ pageContent.pageTitle if pageContent.pageTitle else pageContent.title + " - Digital Land"}}</title>
     <id>{{ staticPath }}/{{parentDir}}/atom.xml</id>
     <updated>{{ publishedDateTime }}</updated>
@@ -21,7 +22,7 @@
         <link rel="alternate" type="text/html" href="{{ itemUrl }}"/>
         <id>{{ itemUrl }}</id>
         {% if i.summary %}
-        <summary type="html">{{ i.summary|markdown|safe }}</summary>
+        <summary type="html">{{ i.summary|markdown|e }}</summary>
         {%- endif %}
     </entry>
     {%- endfor %}

--- a/templates/atom.xml.html
+++ b/templates/atom.xml.html
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-GB">
+    <title>{{ pageContent.pageTitle if pageContent.pageTitle else pageContent.title + " - Digital Land"}}</title>
+    <id>{{ staticPath }}/{{parentDir}}/atom.xml</id>
+    <updated>{{ publishedDateTime }}</updated>
+    {% for i in pageContent.pages %}
+        {% set absoluteUrl = staticPath + "/" + parentDir + "/" + i.url %}
+        {% set itemUrl = i.frontmatter.external_url if i.frontmatter.external_url is defined else absoluteUrl %}
+    <entry xml:lang="en-GB">
+        <title>{{ i.title }}</title>
+        {% if i.frontmatter.date -%}
+        <published>{{ i.frontmatter.date }}</published>
+        {%- endif %}
+        {% if i.frontmatter.author -%}
+        <author>
+          <name>
+            {{ i.frontmatter.author }}
+          </name>
+        </author>
+        {%- endif %}
+        <link rel="alternate" type="text/html" href="{{ itemUrl }}"/>
+        <id>{{ itemUrl }}</id>
+        {% if i.summary %}
+        <summary type="html">{{ i.summary|markdown|safe }}</summary>
+        {%- endif %}
+    </entry>
+    {%- endfor %}
+</feed>

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -1,5 +1,6 @@
 {% extends "content-base.html" %}
 {% block dlMetaTemplate %}<meta name="dl-template" content="digital-land.github.io/blog.html">{% endblock %}
+{% block dlHead %}<link rel="alternate" type="application/atom+xml" title="{{ pageContent.title }} feed" href="atom.xml">{% endblock %}
 
 {% block content %}
 <h1 class="govuk-heading-xl">{{ pageContent.title }}</h1>


### PR DESCRIPTION
[Steve Messer mentioned](https://visitmy.website/2024/03/10/the-full-circle/) that he had tried to add a feed for the blog, but not quite got there. I thought I'd have a quick pass.

This is a naive implementation which was intended to be minimally invasive or overly implementation specific. It adds a feed for every _list.md, even ones where _list.md is the only file in a subdirectory of content.

It reuses the data created during publication of a list as its input - this means a feed should always match the relevant list page.

The only customisations I had to make were exposing the parent_path and a publish date to the template in order to get absolute URLs and make some of the feed values valid. It's possible that parent_path is passed to the template already but I couldn't see it.

I have not committed the generated changes to files in docs/ since I think the GitHub Action is supposed to do that, but they are all published correctly locally during a `make render`.